### PR TITLE
Add Raw Mode in `paste!` macro to allow generating Raw Identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@ Macros for all your token pasting needs
 [<img alt="docs.rs" src="https://img.shields.io/badge/docs.rs-pastey-66c2a5?style=for-the-badge&labelColor=555555&logo=docs.rs" height="20">](https://docs.rs/pastey)
 [<img alt="build status" src="https://img.shields.io/github/actions/workflow/status/as1100k/pastey/ci.yml?branch=master&style=for-the-badge" height="20">](https://github.com/as1100k/pastey/actions?query=branch%master)
 
-**_This crate is the successor of [paste crate](https://github.com/dtolnay/paste)_**
+**_`pastey` is the fork of `paste` and is aimed to be a drop-in replacement with additional features for
+`paste` crate_**
 
 <details>
-<summary>Migrating from `paste` crate</summary>
+<summary>Migrating from <code>paste</code> crate</summary>
 
 Migrating from `paste` crate to `pastey` is super simple, just change the following in your `Cargo.toml`
 
@@ -164,6 +165,39 @@ The precise Unicode conversions are as defined by [`str::to_lowercase`] and
 
 <br>
 
+## Raw Identifier Generation
+
+`pastey` now supports raw identifiers using a special raw mode. By prefixing a token with `#`
+inside the paste syntax, it treats that token as a raw identifier.
+
+```rust
+use pastey::paste;
+
+macro_rules! define_struct_and_impl {
+    ($name:ident $(- $name_tail:ident)*) => {
+        paste!{
+            struct [< # $name:camel $( $name_tail)* >]; // '#' signals a raw identifier
+
+            impl [< # $name:camel $( $name_tail)* >] {
+                fn [< # $name:snake $( _ $name_tail:snake)* >]() {}
+            }
+
+        }
+    }
+}
+
+define_struct_and_impl!(loop);
+define_struct_and_impl!(loop - xyz);
+
+#[test]
+fn test_fn() {
+    let _ = Loop::r#loop();
+    let _ = Loopxyz::loop_xyz();
+}
+```
+
+<br>
+
 ## Pasting documentation strings
 
 Within the `paste!` macro, arguments to a #\[doc ...\] attribute are implicitly
@@ -191,7 +225,7 @@ method_new!(Pastey);  // expands to #[doc = "Create a new `Paste` object"]
 #### Credits
 
 <sup>
-This crate is the fork of [paste](https://github.com/dtolnay/paste) and I appreciate the efforts of
+This crate is the fork of <a href="https://github.com/dtolnay/paste"><code>paste</code></a> and I appreciate the efforts of
 @dtolnay and other contributors.
 </sup>
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,6 @@ macro_rules! define_struct_and_impl {
 define_struct_and_impl!(loop);
 define_struct_and_impl!(loop - xyz);
 
-#[test]
 fn test_fn() {
     let _ = Loop::r#loop();
     let _ = Loopxyz::loop_xyz();

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Macros for all your token pasting needs
 **_`pastey` is the fork of `paste` and is aimed to be a drop-in replacement with additional features for
 `paste` crate_**
 
+<br/>
+
 <details>
 <summary>Migrating from <code>paste</code> crate</summary>
 
@@ -31,9 +33,6 @@ Or even better way:
 </details>
 
 <br>
-
-This crate aims to be a drop-in replacement for `paste` and doesn't change any existing behaviour while
-adding features and fixing bugs. [See Case Conversion for more info](#case-conversion)
 
 ## Quick Start
 

--- a/pastey-test-suite/tests/test_attr.rs
+++ b/pastey-test-suite/tests/test_attr.rs
@@ -60,3 +60,19 @@ fn test_path_in_attr() {
 
     assert_eq!("foo::Bar", ty);
 }
+
+#[test]
+fn test_paste_raw_mode() {
+    macro_rules! m {
+        ($name:ident) => {
+            paste! {
+                #[paste_test(k = "value" [< # $name >])]
+                struct [<# $name:camel>];
+            }
+        };
+    }
+
+    m!(r#loop);
+
+    let _ = Loop;
+}

--- a/pastey-test-suite/tests/test_attr.rs
+++ b/pastey-test-suite/tests/test_attr.rs
@@ -72,7 +72,7 @@ fn test_paste_raw_mode() {
         };
     }
 
-    m!(r#loop);
+    m!(loop);
 
     let _ = Loop;
 }

--- a/pastey-test-suite/tests/test_item.rs
+++ b/pastey-test-suite/tests/test_item.rs
@@ -311,3 +311,56 @@ mod test_pat_in_expr_position {
 
     rav1e_bad!(std::fmt::Error);
 }
+
+mod test_raw_mode {
+    use pastey::paste;
+
+    macro_rules! m{
+        ($name:ident $(- $name_tail:ident)*) => {
+            paste!{
+                struct [< # $name:camel $( $name_tail)* >];
+
+                impl [< # $name:camel $( $name_tail)* >] {
+                    fn [< # $name:snake $( _ $name_tail:snake)* >]() {}
+                }
+
+            }
+        }
+    }
+
+    m!(r#loop);
+    m!(r#loop - xyz);
+
+    #[test]
+    fn test_fn() {
+        let _ = Loop::r#loop();
+        let _ = Loopxyz::loop_xyz();
+    }
+}
+
+mod test_join {
+    use pastey::paste;
+
+    macro_rules! m {
+        ($name:ident, $func:ident) => {
+            paste! {
+                struct [< # $name:camel >];
+
+                impl [< # $name:camel >] {
+                    fn [< $func:snake >](&self) {}
+
+                    fn test()  {
+                        [< # $name:camel >].[< $func:snake >]()
+                    }
+                }
+            }
+        };
+    }
+
+    m!(r#loop, welcome);
+
+    #[test]
+    fn test_fn() {
+        Loop::test();
+    }
+}

--- a/pastey-test-suite/tests/test_item.rs
+++ b/pastey-test-suite/tests/test_item.rs
@@ -318,9 +318,9 @@ mod test_raw_mode {
     macro_rules! m{
         ($name:ident $(- $name_tail:ident)*) => {
             paste!{
-                struct [< # $name:camel $( $name_tail)* >];
+                struct [< $name:camel $( $name_tail)* >];
 
-                impl [< # $name:camel $( $name_tail)* >] {
+                impl [< $name:camel $( $name_tail)* >] {
                     fn [< # $name:snake $( _ $name_tail:snake)* >]() {}
                 }
 
@@ -328,13 +328,17 @@ mod test_raw_mode {
         }
     }
 
-    m!(r#loop);
-    m!(r#loop - xyz);
+    m!(loop);
+    m!(loop - xyz);
+    m!(dyn);
+    m!(unsafe);
 
     #[test]
     fn test_fn() {
         let _ = Loop::r#loop();
         let _ = Loopxyz::loop_xyz();
+        let _ = Dyn::r#dyn();
+        let _ = Unsafe::r#unsafe();
     }
 }
 
@@ -357,7 +361,7 @@ mod test_join {
         };
     }
 
-    m!(r#loop, welcome);
+    m!(loop, welcome);
 
     #[test]
     fn test_fn() {

--- a/pastey-test-suite/tests/ui/invalid-ident.rs
+++ b/pastey-test-suite/tests/ui/invalid-ident.rs
@@ -12,4 +12,8 @@ paste! {
     fn [<f "'">]() {}
 }
 
+paste! {
+    fn [< loop >]() {}
+}
+
 fn main() {}

--- a/pastey-test-suite/tests/ui/invalid-ident.stderr
+++ b/pastey-test-suite/tests/ui/invalid-ident.stderr
@@ -24,3 +24,14 @@ error: `"f'"` is not a valid identifier
    |
 12 |     fn [<f "'">]() {}
    |        ^^^^^^^^^
+
+error: expected identifier, found keyword `loop`
+  --> tests/ui/invalid-ident.rs:16:8
+   |
+16 |     fn [< loop >]() {}
+   |        ^^^^^^^^^^ expected identifier, found keyword
+   |
+help: escape `loop` to use it as an identifier
+   |
+16 |     fn r#[< loop >]() {}
+   |        ++

--- a/pastey-test-suite/tests/ui/raw-mode-wrong-position.rs
+++ b/pastey-test-suite/tests/ui/raw-mode-wrong-position.rs
@@ -1,0 +1,13 @@
+use pastey::paste;
+
+macro_rules! m {
+    ($name:ident) => {
+        paste! {
+            struct [< $name:camel # >];
+        }
+    };
+}
+
+m!(r#loop);
+
+fn main() {}

--- a/pastey-test-suite/tests/ui/raw-mode-wrong-position.stderr
+++ b/pastey-test-suite/tests/ui/raw-mode-wrong-position.stderr
@@ -1,0 +1,10 @@
+error: `#` is reserved keyword and it enables the raw mode (i.e. generate Raw Identifiers) and it is only allowed in the beginning like `[< # ... >]`
+  --> tests/ui/raw-mode-wrong-position.rs:6:35
+   |
+6  |             struct [< $name:camel # >];
+   |                                   ^
+...
+11 | m!(r#loop);
+   | ---------- in this macro invocation
+   |
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -127,6 +127,13 @@ fn do_paste_name_value_attr(attr: TokenStream, span: Span, leading: usize) -> Re
     }
 
     let mut lit = segment::paste(&segments)?;
+
+    if lit.starts_with("r#") {
+        // Raw mode doesn't have any impact when using in attribute
+        lit.remove(0);
+        lit.remove(0);
+    }
+
     lit.insert(0, '"');
     lit.push('"');
 

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -154,14 +154,13 @@ pub(crate) fn paste(segments: &[Segment]) -> Result<String> {
                         // Enable Raw mode
                         evaluated.push(String::from("r#"));
                         continue;
-                    } else {
-                        return Err(Error::new(
-                            segment.span,
-                            "`#` is reserved keyword and it enables the raw mode \
+                    }
+                    return Err(Error::new(
+                        segment.span,
+                        "`#` is reserved keyword and it enables the raw mode \
                             (i.e. generate Raw Identifiers) and it is only allowed in \
                             the beginning like `[< # ... >]`",
-                        ));
-                    }
+                    ));
                 }
                 evaluated.push(segment.value.clone());
             }

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -119,6 +119,10 @@ pub(crate) fn parse(tokens: &mut Peekable<token_stream::IntoIter>) -> Result<Vec
                     };
                     segments.push(Segment::Modifier(colon, ident));
                 }
+                '#' => segments.push(Segment::String(LitStr {
+                    value: "#".to_string(),
+                    span: punct.span(),
+                })),
                 _ => return Err(Error::new(punct.span(), "unexpected punct")),
             },
             TokenTree::Group(group) => {
@@ -142,9 +146,23 @@ pub(crate) fn paste(segments: &[Segment]) -> Result<String> {
     let mut evaluated = Vec::new();
     let mut is_lifetime = false;
 
-    for segment in segments {
+    for (i, segment) in segments.iter().enumerate() {
         match segment {
             Segment::String(segment) => {
+                if segment.value.as_str() == "#" {
+                    if i == 0 {
+                        // Enable Raw mode
+                        evaluated.push(String::from("r#"));
+                        continue;
+                    } else {
+                        return Err(Error::new(
+                            segment.span,
+                            "`#` is reserved keyword and it enables the raw mode \
+                            (i.e. generate Raw Identifiers) and it is only allowed in \
+                            the beginning like `[< # ... >]`",
+                        ));
+                    }
+                }
                 evaluated.push(segment.value.clone());
             }
             Segment::Apostrophe(span) => {


### PR DESCRIPTION
- [x] Update README.md

Fixes #7 

This PR adds Raw mode to the `paste!` macro. The following syntax can generate raw identifiers:

```rust
use pastey::paste;

macro_rules! m{
    ($name:ident $(- $name_tail:ident)*) => {
        paste!{
            struct [< # $name:camel $( $name_tail)* >];

            impl [< # $name:camel $( $name_tail)* >] {
                fn [< # $name:snake $( _ $name_tail:snake)* >]() {}
            }

        }
    }
}

m!(loop);
m!(loop - xyz);

#[test]
fn test_fn() {
    let _ = Loop::r#loop();
    let _ = Loopxyz::loop_xyz();
}
```

## Concerns

I am not entirely sure that I would go with having `#` as the keyword to enable raw mode