### PR TITLE
Fix CI

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -23,6 +23,13 @@ echo "========================================"
 echo "Running tests with pastey-test-suite crate..."
 echo "========================================"
 cd pastey-test-suite
+
+# Set some packages to their precise version to avoid MSRV conflict
+if [[ "$1" == "1.56.0" ]]; then
+    cargo update -p quote --precise 1.0.40
+    cargo update -p glob --precise 0.3.2
+fi
+
 cargo test
 rm ./tests/ui/case-warning.stderr
 rm ./tests/ui/raw-mode-wrong-position.stderr


### PR DESCRIPTION
This pull request introduces a conditional step to the `test.sh` script to address Minimum Supported Rust Version (MSRV) conflicts when running tests with the `pastey-test-suite` crate. Specifically, it ensures that certain dependencies are set to precise versions if the script is invoked with Rust version `1.56.0`.

Dependency version management:

* In `test.sh`, added a conditional block to set the `quote` and `glob` package versions to `1.0.40` and `0.3.2` respectively when the script argument is `1.56.0`, helping avoid MSRV conflicts.