### PR TITLE
Exclude development scripts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ keywords = ["macros"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/as1100k/pastey"
 rust-version = "1.54"
+include = ["CHANGELOG.md", "LICENSE-APACHE", "LICENSE-MIT", "README.md", "Cargo.toml", "src/**/*.rs"]
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
During a dependency review we noticed that the pastey crate includes various development scripts. These development scripts shouldn't be there as they might, at some point become problematic. As of now they prevent any downstream user from enabling the `[bans.build.interpreted]` option of cargo deny.

I opted for using an explicit include list instead of an exclude list to prevent these files from beeing included in the published packages to make sure that everything that's included is an conscious choice.